### PR TITLE
Add timeline token to config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -27,6 +27,16 @@ exports.onConfigChanged = function() {
   Util.error('Internal Error', 'Config.onConfigChanged not set!');
 };
 
+// Fetch Timeline token for display on configuration page
+Pebble.getTimelineToken(
+  function (token) {
+    Settings.option('token', token);
+  },
+  function (error) {
+    console.log('Error getting timeline token: ' + error);
+  }
+);
+
 // populate exports and initialize Settings
 function getConfig() {
   var localUrl = 'http://demo.openhab.org:8080';


### PR DESCRIPTION
Hey,

I've been working on an openHAB action that can push pins to the timeline on Pebble watches. More information can be found in this forum post: https://community.openhab.org/t/pebble-timeline-action/4916/1

To use this, you need the timeline token from the openHAB watch app. This pull request display this token on the configuration page. I first wanted to show this token on the watch app, but copying this from the tiny screen is not that easy :smiley: 

This pull requests needs two additional actions:
- Update of the configuration HTML page, see #15
- Enable timeline functionality for the app in the pebble dev center. This is described here: https://developer.getpebble.com/guides/timeline/timeline-enabling (just one push of a button)

Let me know if you need any more information. 
